### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/acme-bots.template
+++ b/acme-bots.template
@@ -122,7 +122,7 @@ Resources:
     Properties: 
       Handler: "index.clearS3Bucket"
       Role: !GetAtt LambdaExecutionS3CleanupRole.Arn
-      Runtime: "nodejs8.10"
+      Runtime: "nodejs10.x"
       Timeout: 25
       Code: 
         ZipFile: >


### PR DESCRIPTION
CloudFormation templates in aws-iot-core-acmebots-monitoring have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.