### PR TITLE
NodeJS 12.x Lambda Runtime Update

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -170,7 +170,7 @@ functions:
                         - "acmebots.status"
     ecsProvisionBot:
         handler: src/bot/ecsProvisionBot.ecsProvisionBot
-        runtime: nodejs8.10
+        runtime: nodejs12.x
         timeout: 25
         environment:
             TASK_EXEC_ROLE_ARN:
@@ -196,7 +196,7 @@ functions:
 
     ecsDeleteBot:
         handler: src/bot/ecsDeleteBot.ecsDeleteBot
-        runtime: nodejs8.10
+        runtime: nodejs12.x
         timeout: 25
         environment:
             SERVICE: ${self:service}
@@ -469,7 +469,7 @@ resources:
             Handler: clear-s3-bucket.clearS3Bucket
             Role: 
               Fn::GetAtt: LambdaExecutionCleanupRole.Arn
-            Runtime: nodejs8.10
+            Runtime: nodejs12.x
             Timeout: 25
             Code: 
               S3Bucket: ${self:custom.LambdaS3Bucket}
@@ -482,7 +482,7 @@ resources:
             Handler: clear-ecr-repo.clearEcrRepo
             Role:
               Fn::GetAtt: LambdaExecutionCleanupRole.Arn
-            Runtime: nodejs8.10
+            Runtime: nodejs12.x
             Timeout: 25
             Code:
               S3Bucket: ${self:custom.LambdaS3Bucket}
@@ -495,7 +495,7 @@ resources:
             Handler: clear-ecs-cluster.clearEcsCluster
             Role:
               Fn::GetAtt: LambdaExecutionCleanupRole.Arn
-            Runtime: nodejs8.10
+            Runtime: nodejs12.x
             Timeout: 25
             Code:
               S3Bucket: ${self:custom.LambdaS3Bucket}
@@ -508,7 +508,7 @@ resources:
             Handler: detachPrincipals.clearPrincipals
             Role:
               Fn::GetAtt: LambdaExecutionCleanupRole.Arn
-            Runtime: nodejs8.10
+            Runtime: nodejs12.x
             Timeout: 25
             Code:
               S3Bucket: ${self:custom.LambdaS3Bucket}

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -47,7 +47,7 @@ provider:
     stage: dev
     region: us-east-1
     deploymentBucket: mybuckethere
-    runtime: nodejs8.10
+    runtime: nodejs12.x
     tracing: true
     # Look at 'serverless-iam-roles-per-function' plugin to define roles per function
     iamRoleStatements: # permissions for all of your functions can be set here


### PR DESCRIPTION
NodeJS8.10 appears to no longer be a supported Lambda runtime.  Upgrade to NodeJS12.x.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
