### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/acme-bots.template
+++ b/acme-bots.template
@@ -122,7 +122,7 @@ Resources:
     Properties: 
       Handler: "index.clearS3Bucket"
       Role: !GetAtt LambdaExecutionS3CleanupRole.Arn
-      Runtime: "nodejs10.x"
+      Runtime: "nodejs14.x"
       Timeout: 25
       Code: 
         ZipFile: >


### PR DESCRIPTION
CloudFormation templates in aws-iot-core-acmebots-monitoring have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.